### PR TITLE
Logrotate implementation

### DIFF
--- a/fluentbit/Dockerfile
+++ b/fluentbit/Dockerfile
@@ -32,7 +32,7 @@ RUN set -ex; \
     percona-xtradb-cluster-client-${PERCONA_VERSION} tar vim-minimal; \
     curl -Lf https://github.com/michaloo/go-cron/releases/download/v0.0.2/go-cron.tar.gz -o /tmp/go-cron.tar.gz; \
     tar xvf /tmp/go-cron.tar.gz -C /usr/bin; \
-    curl -Lf https://packages.fluentbit.io/centos/9/x86_64/x86_64/fluent-bit-3.2.2-1.x86_64.rpm -o /tmp/fluent-bit.rpm \
+    curl -Lf https://packages.fluentbit.io/centos/9/x86_64/x86_64/fluent-bit-3.2.2-1.x86_64.rpm -o /tmp/fluent-bit.rpm; \
     rpmkeys --checksig /tmp/fluent-bit.rpm; \
     rpm -i /tmp/fluent-bit.rpm; \
     rm -rf /var/cache

--- a/fluentbit/Dockerfile
+++ b/fluentbit/Dockerfile
@@ -32,11 +32,10 @@ RUN set -ex; \
     percona-xtradb-cluster-client-${PERCONA_VERSION} tar vim-minimal; \
     curl -Lf https://github.com/michaloo/go-cron/releases/download/v0.0.2/go-cron.tar.gz -o /tmp/go-cron.tar.gz; \
     tar xvf /tmp/go-cron.tar.gz -C /usr/bin; \
-    curl -Lf https://packages.fluentbit.io/centos/9/x86_64/x86_64/fluent-bit-3.2.2-1.x86_64.rpm -o /tmp/fluent-bit.rpm; \
+    curl -Lf https://packages.fluentbit.io/centos/9/x86_64/fluent-bit-3.2.2-1.x86_64.rpm -o /tmp/fluent-bit.rpm; \
     rpmkeys --checksig /tmp/fluent-bit.rpm; \
     rpm -i /tmp/fluent-bit.rpm; \
     rm -rf /var/cache
-
 
 RUN groupadd -g 1001 mysql
 RUN useradd -u 1001 -r -g 1001 -s /sbin/nologin \

--- a/fluentbit/Dockerfile
+++ b/fluentbit/Dockerfile
@@ -28,7 +28,7 @@ ENV PERCONA_VERSION 8.0.39-30.1.el9
 
 # fluentbit does not have el8 repo and the doc suggests installing el7 rpm
 RUN set -ex; \
-    microdnf install -y hostname postgresql-libs shadow-utils yum-utils logrotate make libpq procps-ng compat-openssl11 \
+    microdnf install -y hostname postgresql-libs shadow-utils yum-utils logrotate make libpq procps-ng compat-openssl11 util-linux \
     percona-xtradb-cluster-client-${PERCONA_VERSION} tar vim-minimal; \
     curl -Lf https://github.com/michaloo/go-cron/releases/download/v0.0.2/go-cron.tar.gz -o /tmp/go-cron.tar.gz; \
     tar xvf /tmp/go-cron.tar.gz -C /usr/bin; \

--- a/fluentbit/Dockerfile
+++ b/fluentbit/Dockerfile
@@ -32,7 +32,7 @@ RUN set -ex; \
     percona-xtradb-cluster-client-${PERCONA_VERSION} tar vim-minimal; \
     curl -Lf https://github.com/michaloo/go-cron/releases/download/v0.0.2/go-cron.tar.gz -o /tmp/go-cron.tar.gz; \
     tar xvf /tmp/go-cron.tar.gz -C /usr/bin; \
-    curl -Lf https://packages.fluentbit.io/centos/9/x86_64/fluent-bit-3.2.2-1.x86_64.rpm -o /tmp/fluent-bit.rpm; \
+    curl -Lf https://packages.fluentbit.io/centos/9/x86_64/x86_64/fluent-bit-3.2.2-1.x86_64.rpm -o /tmp/fluent-bit.rpm \
     rpmkeys --checksig /tmp/fluent-bit.rpm; \
     rpm -i /tmp/fluent-bit.rpm; \
     rm -rf /var/cache

--- a/fluentbit/Dockerfile
+++ b/fluentbit/Dockerfile
@@ -32,7 +32,9 @@ RUN set -ex; \
     percona-xtradb-cluster-client-${PERCONA_VERSION} tar vim-minimal; \
     curl -Lf https://github.com/michaloo/go-cron/releases/download/v0.0.2/go-cron.tar.gz -o /tmp/go-cron.tar.gz; \
     tar xvf /tmp/go-cron.tar.gz -C /usr/bin; \
-    curl -Lf https://packages.fluentbit.io/centos/9/x86_64/fluent-bit-3.2.2-1.x86_64.rpm -o /tmp/fluent-bit.rpm; \
+    curl -fL --retry 5 --retry-delay 3 \
+    https://packages.fluentbit.io/centos/9/fluent-bit-3.2.2-1.x86_64.rpm \
+    -o /tmp/fluent-bit.rpm; \
     rpmkeys --checksig /tmp/fluent-bit.rpm; \
     rpm -i /tmp/fluent-bit.rpm; \
     rm -rf /var/cache

--- a/fluentbit/Makefile
+++ b/fluentbit/Makefile
@@ -2,7 +2,8 @@ BUILDDIR=$(CURDIR)
 registry_url ?= quay.io
 image_name = ${registry_url}/platform9/percona-xtradb-cluster-operator
 DOCKERFILE?=$(BUILDDIR)/Dockerfile
-image_tag = v1.16.1-pf9-ipv6-logcollector-fluentbit3.2.2-flaco
+image_tag = v1.16.1-pf9-ipv6-logcollector-fluentbit3.2.2-test
+# keeping the image tag different so this won't overide the prod image
 PF9_TAG=$(image_name):${image_tag}
 DOCKERARGS=
 ifdef HTTP_PROXY

--- a/fluentbit/Makefile
+++ b/fluentbit/Makefile
@@ -1,0 +1,22 @@
+BUILDDIR=$(CURDIR)
+registry_url ?= quay.io
+image_name = ${registry_url}/platform9/percona-xtradb-cluster-operator
+DOCKERFILE?=$(BUILDDIR)/Dockerfile
+image_tag = v1.16.1-pf9-ipv6-logcollector-fluentbit3.2.2-test
+PF9_TAG=$(image_name):${image_tag}
+DOCKERARGS=
+ifdef HTTP_PROXY
+	DOCKERARGS += --build-arg http_proxy=$(HTTP_PROXY)
+endif
+ifdef HTTPS_PROXY
+	DOCKERARGS += --build-arg https_proxy=$(HTTPS_PROXY)
+endif
+
+pf9-image: | $(BUILDDIR) ; $(info Building Docker image for pf9 Repo...) @ ## Build percona operator logcollector image
+	@docker build -t $(PF9_TAG) -f $(DOCKERFILE)  $(CURDIR) $(DOCKERARGS)
+	echo ${PF9_TAG} > $(BUILDDIR)/container-tag
+
+pf9-push: 
+	docker login
+	docker push $(PF9_TAG)\
+	&& docker rmi $(PF9_TAG)

--- a/fluentbit/Makefile
+++ b/fluentbit/Makefile
@@ -2,7 +2,7 @@ BUILDDIR=$(CURDIR)
 registry_url ?= quay.io
 image_name = ${registry_url}/platform9/percona-xtradb-cluster-operator
 DOCKERFILE?=$(BUILDDIR)/Dockerfile
-image_tag = v1.16.1-pf9-ipv6-logcollector-fluentbit3.2.2-test
+image_tag = v1.16.1-pf9-ipv6-logcollector-fluentbit3.2.2-flaco
 PF9_TAG=$(image_name):${image_tag}
 DOCKERARGS=
 ifdef HTTP_PROXY

--- a/fluentbit/dockerdir/entrypoint.sh
+++ b/fluentbit/dockerdir/entrypoint.sh
@@ -12,7 +12,7 @@ if [  "$1" = 'logrotate' ]; then
         rm -rf /tmp/passwd
     fi
     # Use flock to prevent concurrent logrotate runs
-    exec go-cron "0 0 * * *" sh -c "flock -n /var/lock/logrotate-mysql.lock logrotate -s /opt/percona/logrotate/logrotate.status /opt/percona/logrotate/logrotate-$SERVICE_TYPE.conf; /usr/bin/find /var/lib/mysql/ -name GRA_*.log -mtime +7 -delete"
+    exec go-cron "0 */6 * * *" sh -c "flock -n /var/lock/logrotate-mysql.lock logrotate -s /opt/percona/logrotate/logrotate.status /opt/percona/logrotate/logrotate-$SERVICE_TYPE.conf; /usr/bin/find /var/lib/mysql/ -name GRA_*.log -mtime +7 -delete"
 else
     if [ "$1" = 'fluent-bit' ]; then
         fluentbit_opt+='-c /etc/fluentbit/fluentbit.conf'

--- a/fluentbit/dockerdir/entrypoint.sh
+++ b/fluentbit/dockerdir/entrypoint.sh
@@ -11,7 +11,8 @@ if [  "$1" = 'logrotate' ]; then
         cat /tmp/passwd > /etc/passwd
         rm -rf /tmp/passwd
     fi
-    exec go-cron "0 0 * * *" sh -c "logrotate -s /opt/percona/logrotate/logrotate.status /opt/percona/logrotate/logrotate-$SERVICE_TYPE.conf;/usr/bin/find /var/lib/mysql/ -name GRA_*.log -mtime +7 -delete"
+    # Use flock to prevent concurrent logrotate runs
+    exec go-cron "0 0 * * *" sh -c "flock -n /var/lock/logrotate-mysql.lock logrotate -s /opt/percona/logrotate/logrotate.status /opt/percona/logrotate/logrotate-$SERVICE_TYPE.conf; /usr/bin/find /var/lib/mysql/ -name GRA_*.log -mtime +7 -delete"
 else
     if [ "$1" = 'fluent-bit' ]; then
         fluentbit_opt+='-c /etc/fluentbit/fluentbit.conf'

--- a/fluentbit/dockerdir/opt/percona/logrotate/logrotate-mysql.conf
+++ b/fluentbit/dockerdir/opt/percona/logrotate/logrotate-mysql.conf
@@ -1,13 +1,9 @@
 /var/lib/mysql/[!G]*.log {
-   daily
-   minsize 10M
-   maxsize 100M
+   size 200M
    rotate 10
+   compress
+   delaycompress
    missingok
-   nocompress
    notifempty
-   sharedscripts
-   postrotate
-       /usr/local/bin/postrotate-mysql.sh
-   endscript
+   copytruncate
 }

--- a/percona-xtradb-cluster-5.7-backup/Makefile
+++ b/percona-xtradb-cluster-5.7-backup/Makefile
@@ -3,6 +3,7 @@ registry_url ?= quay.io
 image_name = ${registry_url}/platform9/percona-xtradb-cluster-operator
 DOCKERFILE?=$(BUILDDIR)/Dockerfile
 image_tag = v1.16.1-pf9-ipv6-pxc5.7-backup-test
+# keeping the image tag different so this won't overide the prod image
 PF9_TAG=$(image_name):${image_tag}
 DOCKERARGS=
 ifdef HTTP_PROXY

--- a/percona-xtradb-cluster-5.7-backup/Makefile
+++ b/percona-xtradb-cluster-5.7-backup/Makefile
@@ -2,7 +2,7 @@ BUILDDIR=$(CURDIR)
 registry_url ?= quay.io
 image_name = ${registry_url}/platform9/percona-xtradb-cluster-operator
 DOCKERFILE?=$(BUILDDIR)/Dockerfile
-image_tag = v1.16.1-pf9-ipv6-pxc5.7-backup
+image_tag = v1.16.1-pf9-ipv6-pxc5.7-backup-test
 PF9_TAG=$(image_name):${image_tag}
 DOCKERARGS=
 ifdef HTTP_PROXY

--- a/percona-xtradb-cluster-8.0-backup/Makefile
+++ b/percona-xtradb-cluster-8.0-backup/Makefile
@@ -2,7 +2,7 @@ BUILDDIR=$(CURDIR)
 registry_url ?= quay.io
 image_name = ${registry_url}/platform9/percona-xtradb-cluster-operator
 DOCKERFILE?=$(BUILDDIR)/Dockerfile
-image_tag = v1.16.1-pf9-ipv6-pxc8.0-backup
+image_tag = v1.16.1-pf9-ipv6-pxc8.0-backup-test
 PF9_TAG=$(image_name):${image_tag}
 DOCKERARGS=
 ifdef HTTP_PROXY

--- a/percona-xtradb-cluster-8.0-backup/Makefile
+++ b/percona-xtradb-cluster-8.0-backup/Makefile
@@ -3,6 +3,7 @@ registry_url ?= quay.io
 image_name = ${registry_url}/platform9/percona-xtradb-cluster-operator
 DOCKERFILE?=$(BUILDDIR)/Dockerfile
 image_tag = v1.16.1-pf9-ipv6-pxc8.0-backup-test
+# keeping the image tag different so this won't overide the prod image
 PF9_TAG=$(image_name):${image_tag}
 DOCKERARGS=
 ifdef HTTP_PROXY


### PR DESCRIPTION
Jira:-https://platform9.atlassian.net/browse/PCD-4595

Related PR's :- https://github.com/platform9/airctl/pull/1662

Testing
```
root@ce-ce-ce:/home/ubuntu# kubectl exec -it -n pcd percona-db-pxc-db-pxc-0 -c logrotate -- ps aux
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
mysql          1  0.0  0.0 266556  2176 ?        Ssl  12:34   0:00 go-cron 0 */6 * * * sh -c flock -n /var/lock/logrotate-mysql.lock logrotate -s /opt/percona/logrotate/logrotate.status /opt/percona/logrotate/logrotate

root@ce-ce-ce:/home/ubuntu# kubectl exec -it -n pcd percona-db-pxc-db-pxc-0 -c pxc -- ls -lh /var/lib/mysql/
total 730M
-rw-rw---- 1 mysql  1002 192K Mar  5 12:40 '#ib_16384_0.dblwr'
-rw-rw---- 1 mysql  1002 8.2M Mar  5 09:32 '#ib_16384_1.dblwr'
drwxrws--- 2 mysql  1002 4.0K Mar  5 12:35 '#innodb_redo'
drwxrws--- 2 mysql  1002 4.0K Mar  5 12:35 '#innodb_temp'
drwxrws--- 2 mysql  1002 4.0K Mar  5 09:32  alertmanager
-rw-rw-r-- 1 mysql  1002   22 Mar  5 12:34  auth_plugin
-rw-rw---- 1 mysql  1002   56 Mar  5 09:25  auto.cnf
-rw-rw---- 1 mysql  1002  180 Mar  5 09:26  binlog.000001
-rw-rw---- 1 mysql  1002 202K Mar  5 12:16  binlog.000002
-rw-r----- 1 mysql  1002  197 Mar  5 12:35  binlog.000003
-rw-r----- 1 mysql  1002   48 Mar  5 12:35  binlog.index
-rw-rw---- 1 mysql  1002 129M Mar  5 12:34  galera.cache
-rwxr-xr-x 1 mysql mysql 1.2K Mar  5 12:31  get-pxc-state
-rw-rw---- 1 mysql  1002  114 Mar  5 12:34  grastate.dat
-rw-r----- 1 mysql  1002  170 Mar  5 12:34  gvwstate.dat
drwxrws--- 2 mysql  1002 4.0K Mar  5 09:38  hagrid
-rw-rw---- 1 mysql  1002 6.6K Mar  5 12:16  ib_buffer_pool
-rw-rw---- 1 mysql  1002  12M Mar  5 12:40  ibdata1
-rw-r----- 1 mysql  1002  12M Mar  5 12:35  ibtmp1
drwxrws--- 2 mysql  1002 4.0K Mar  5 09:40  keystone
-rwxr-xr-x 1 mysql mysql 1.7K Mar  5 12:31  liveness-check.sh
drwxrws--- 2 mysql  1002 4.0K Mar  5 09:26  mysql
-rwxr-xr-x 1 mysql mysql 1.7M Mar  5 12:31  mysql-state-monitor
-rw-rw-r-- 1 mysql  1002    0 Mar  5 13:04  mysql-state-monitor.log
-rw-rw-r-- 1 mysql  1002 1.3K Mar  5 13:04  mysql-state-monitor.log.1
-rw-rw---- 1 mysql  1002  31M Mar  5 12:35  mysql.ibd
-rw-rw-r-- 1 mysql  1002   96 Mar  5 12:35  mysql.state
-rw-rw---- 1 mysql  1002    0 Mar  5 13:19  mysqld-error.log <-------current file
-rw-rw---- 1 mysql  1002 500M Mar  5 13:19  mysqld-error.log.1 <---- last rotated log file
-rw-rw---- 1 mysql  1002 9.6K Mar  5 13:04  mysqld-error.log.2.gz <----- previous rotated file
srwxrwxrwx 1 mysql  1002    0 Mar  5 12:35  mysqlx.sock
-rw------- 1 mysql  1002    2 Mar  5 12:35  mysqlx.sock.lock
srwxr-xr-x 1 mysql  1002    0 Mar  5 12:34  notify.sock
-rwxr-xr-x 1 mysql mysql 3.7M Mar  5 12:31  peer-list
-rw-r----- 1 mysql  1002    2 Mar  5 12:35  percona-db-pxc-db-pxc-0.pid
drwxrws--- 2 mysql  1002 4.0K Mar  5 09:25  performance_schema
-rwxr-xr-x 1 mysql mysql  830 Mar  5 12:31  pmm-prerun.sh
drwxrws--- 2 mysql  1002 4.0K Mar  5 09:36  preference_store
-rw-rw---- 1 mysql  1002 1.7K Mar  5 09:25  private_key.pem
-rw-rw-r-- 1 mysql  1002  452 Mar  5 09:25  public_key.pem
-rwxr-xr-x 1 mysql mysql 6.8K Mar  5 12:31  pxc-configure-pxc.sh
-rwxr-xr-x 1 mysql mysql  25K Mar  5 12:31  pxc-entrypoint.sh
-rwxr-xr-x 1 mysql mysql 1.5K Mar  5 12:31  readiness-check.sh
drwxrws--- 2 mysql  1002 4.0K Mar  5 09:32  resmgr
drwxrws--- 2 mysql  1002 4.0K Mar  5 09:25  sys
-rw-rw---- 1 mysql  1002  16M Mar  5 12:36  undo_001
-rw-rw---- 1 mysql  1002  16M Mar  5 12:36  undo_002
-rwxr-xr-x 1 mysql mysql  543 Mar  5 12:31  unsafe-bootstrap.sh
-rw-rw-r-- 1 mysql  1002  142 Mar  5 12:34  version_info

root@ce-ce-ce:/home/ubuntu# kubectl exec -it -n pcd                     percona-db-pxc-db-pxc-0 -c logrotate -- \
cat /opt/percona/logrotate/logrotate-mysql.conf
/var/lib/mysql/[!G]*.log {
   size 200M
   rotate 10
   compress
   delaycompress
   missingok
   notifempty
   copytruncate
}

```