### PR TITLE
Do not run DB backup jobs/log rotate jobs if percona/mysql is down

### DIFF
--- a/percona-xtradb-cluster-5.7-backup/Dockerfile
+++ b/percona-xtradb-cluster-5.7-backup/Dockerfile
@@ -105,7 +105,7 @@ RUN install -d -o 1001 -g 0 -m 0775 /backup; \
 ENV MC_VERSION=RELEASE.2024-11-17T19-35-25Z
 ENV MC_SHA256SUM=544d2d11c32cb4ed11b27338935a9cc434e15b692ff3d1529a624d341fe2ffc5
 RUN set -ex; \
-    curl -o /usr/bin/mc -O https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.${MC_VERSION} \
+    curl -o /usr/bin/mc -LO https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.${MC_VERSION} \
 	&& chmod +x /usr/bin/mc \
 	&& echo "${MC_SHA256SUM} /usr/bin/mc" | sha256sum -c - \
 	&& curl -o /licenses/LICENSE.mc \

--- a/percona-xtradb-cluster-5.7-backup/Makefile
+++ b/percona-xtradb-cluster-5.7-backup/Makefile
@@ -2,8 +2,7 @@ BUILDDIR=$(CURDIR)
 registry_url ?= quay.io
 image_name = ${registry_url}/platform9/percona-xtradb-cluster-operator
 DOCKERFILE?=$(BUILDDIR)/Dockerfile
-image_tag = v1.16.1-pf9-ipv6-pxc5.7-backup-test
-# keeping the image tag different so this won't overide the prod image
+image_tag = v1.16.1-pf9-ipv6-pxc5.7-backup-v2
 PF9_TAG=$(image_name):${image_tag}
 DOCKERARGS=
 ifdef HTTP_PROXY

--- a/percona-xtradb-cluster-5.7-backup/Makefile
+++ b/percona-xtradb-cluster-5.7-backup/Makefile
@@ -2,7 +2,7 @@ BUILDDIR=$(CURDIR)
 registry_url ?= quay.io
 image_name = ${registry_url}/platform9/percona-xtradb-cluster-operator
 DOCKERFILE?=$(BUILDDIR)/Dockerfile
-image_tag = v1.16.1-pf9-ipv6-pxc5.7-backup-v2
+image_tag = v1.16.1-pf9-ipv6-pxc5.7-backup-test
 PF9_TAG=$(image_name):${image_tag}
 DOCKERARGS=
 ifdef HTTP_PROXY

--- a/percona-xtradb-cluster-5.7-backup/get-pxc-state
+++ b/percona-xtradb-cluster-5.7-backup/get-pxc-state
@@ -3,7 +3,7 @@
 function mysql_exec() {
   local server="$1"
   local query="$2"
-  MYSQL_PWD=${PXC_PASS:-password} timeout 600 mysql -P33062 -h${server} -uxtrabackup -s -NB -e "${query}"
+  MYSQL_PWD=${PXC_PASS:-password} timeout 10 mysql --connect-timeout=5 -P33062 -h${server} -uxtrabackup -s -NB -e "${query}"
 }
 
 function wait_for_mysql() {

--- a/percona-xtradb-cluster-8.0-backup/Dockerfile
+++ b/percona-xtradb-cluster-8.0-backup/Dockerfile
@@ -106,7 +106,7 @@ RUN install -d -o 1001 -g 0 -m 0775 /backup; \
 ENV MC_VERSION=RELEASE.2024-11-17T19-35-25Z
 ENV MC_SHA256SUM=544d2d11c32cb4ed11b27338935a9cc434e15b692ff3d1529a624d341fe2ffc5
 RUN set -ex; \
-    curl -o /usr/bin/mc -O https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.${MC_VERSION} \
+    curl -o /usr/bin/mc -LO https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.${MC_VERSION} \
 	&& chmod +x /usr/bin/mc \
 	&& echo "${MC_SHA256SUM} /usr/bin/mc" | sha256sum -c - \
 	&& curl -o /licenses/LICENSE.mc \

--- a/percona-xtradb-cluster-8.0-backup/Makefile
+++ b/percona-xtradb-cluster-8.0-backup/Makefile
@@ -2,7 +2,7 @@ BUILDDIR=$(CURDIR)
 registry_url ?= quay.io
 image_name = ${registry_url}/platform9/percona-xtradb-cluster-operator
 DOCKERFILE?=$(BUILDDIR)/Dockerfile
-image_tag = v1.16.1-pf9-ipv6-pxc8.0-backup-v2
+image_tag = v1.16.1-pf9-ipv6-pxc8.0-backup-test
 PF9_TAG=$(image_name):${image_tag}
 DOCKERARGS=
 ifdef HTTP_PROXY

--- a/percona-xtradb-cluster-8.0-backup/Makefile
+++ b/percona-xtradb-cluster-8.0-backup/Makefile
@@ -2,8 +2,7 @@ BUILDDIR=$(CURDIR)
 registry_url ?= quay.io
 image_name = ${registry_url}/platform9/percona-xtradb-cluster-operator
 DOCKERFILE?=$(BUILDDIR)/Dockerfile
-image_tag = v1.16.1-pf9-ipv6-pxc8.0-backup-test
-# keeping the image tag different so this won't overide the prod image
+image_tag = v1.16.1-pf9-ipv6-pxc8.0-backup-v2
 PF9_TAG=$(image_name):${image_tag}
 DOCKERARGS=
 ifdef HTTP_PROXY

--- a/percona-xtradb-cluster-8.0-backup/get-pxc-state
+++ b/percona-xtradb-cluster-8.0-backup/get-pxc-state
@@ -7,7 +7,7 @@ function mysql_exec() {
   mysql_pass=$(cat /etc/mysql/mysql-users-secret/xtrabackup 2>/dev/null || :)
   MYSQL_PASSWORD="${mysql_pass:-$PXC_PASS}"
 
-  MYSQL_PWD=${MYSQL_PASSWORD} timeout 600 mysql -P33062 -h${server} -uxtrabackup -s -NB -e "${query}"
+  MYSQL_PWD=${MYSQL_PASSWORD} timeout 10 mysql --connect-timeout=5 -P33062 -h${server} -uxtrabackup -s -NB -e "${query}"
   
 }
 

--- a/percona-xtradb-cluster-8.4-backup/Dockerfile
+++ b/percona-xtradb-cluster-8.4-backup/Dockerfile
@@ -106,7 +106,7 @@ RUN install -d -o 1001 -g 0 -m 0775 /backup; \
 ENV MC_VERSION=RELEASE.2024-11-17T19-35-25Z
 ENV MC_SHA256SUM=544d2d11c32cb4ed11b27338935a9cc434e15b692ff3d1529a624d341fe2ffc5
 RUN set -ex; \
-    curl -o /usr/bin/mc -O https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.${MC_VERSION} \
+    curl -o /usr/bin/mc -LO https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.${MC_VERSION} \
 	&& chmod +x /usr/bin/mc \
 	&& echo "${MC_SHA256SUM} /usr/bin/mc" | sha256sum -c - \
 	&& curl -o /licenses/LICENSE.mc \

--- a/percona-xtradb-cluster-8.4-backup/get-pxc-state
+++ b/percona-xtradb-cluster-8.4-backup/get-pxc-state
@@ -7,7 +7,7 @@ function mysql_exec() {
   mysql_pass=$(cat /etc/mysql/mysql-users-secret/xtrabackup 2>/dev/null || :)
   MYSQL_PASSWORD="${mysql_pass:-$PXC_PASS}"
 
-  MYSQL_PWD=${MYSQL_PASSWORD} timeout 600 mysql -P33062 -h${server} -uxtrabackup -s -NB -e "${query}"
+  MYSQL_PWD=${MYSQL_PASSWORD} timeout 10 mysql --connect-timeout=5 -P33062 -h${server} -uxtrabackup -s -NB -e "${query}"
   
 }
 


### PR DESCRIPTION
Jira :- https://platform9.atlassian.net/browse/PCD-5665

Summary:
"Log rotate" part — already fixed. The logrotate mode in fluentbit/dockerdir/entrypoint.sh (percona-docker repo) runs a daily go-cron job that rotates MySQL logs. The prior commit 2d08f5b ("logrotate image change") added flock -n around it, so if MySQL is unresponsive and a run gets stuck, the next day's trigger just skips instead of piling up a new stuck process. Nothing further needed there.
"DB backup jobs" part — this was the actual gap, now fixed. The Percona operator's xtrabackup backup image (percona-xtradb-cluster-*-backup/get-pxc-state) discovers a healthy donor node by querying each PXC pod's wsrep_* status via mysql ... timeout 600 .... When quorum is lost (network outage scenario from the ticket), those connections don't fail fast  they hang for up to 600 seconds per node, and wait_for_mysql retries that up to 10 times, so worst case a single node check could block for ~100 minutes, times 3 nodes. That's what piles up stuck backup processes on the node until kubelet starves matching the incident exactly.

Testing:
Verified the change exists in the image used. 
Confirmed the fix was actually present in the running -test image: cat /usr/bin/get-pxc-state inside an pod showed timeout 10 mysql --connect-timeout=5 ....
Timed it against an unreachable/blackholed IP (10.255.255.1, non-routed):
time timeout 10 mysql --connect-timeout=5 -P33062 -h10.255.255.1 -uxtrabackup -s -NB -e "select 1"
Output: ERROR 2003 ... Can't connect ..., exit_code=1, elapsed=5s (vs. up to 600s pre-fix).
Ran the same probe against the real, healthy percona-db-pxc-db-pxc-0 node (using its actual service DNS name and the real xtrabackup secret password, insecure-xtrabackup-password, pulled from secret/percona-db-pxc-db-secrets): Output: 1, exit_code=0, elapsed=0s — confirms no regression for the healthy path.